### PR TITLE
Harden long-term tracking and polish the listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project are documented here. The format is based
 on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Suspend and clock jumps no longer accrue wall-clock time as screen time: a
+  bucket crossing a suspend gap is dropped instead of counting the whole
+  sleep against today.
+- The idle screensaver and xdg desktop-portal windows no longer count as
+  tracked apps, matching the "idle and locked time is never counted" claim.
+- A corrupt `history.json` is preserved (moved aside) before tracking
+  resumes, instead of being silently overwritten and losing all history.
+- Terminal resolution now also covers Omarchy's own terminal
+  (`org.omarchy.terminal`), which was previously tracked as itself.
+- Panel no longer emits `Unable to assign [undefined] to QString` warnings at
+  startup: chart data is gated on the service being ready, and the Model
+  helpers tolerate empty day keys.
+- Resolver runs are guarded against overlap and a watchdog clears a stuck
+  in-flight resolution so terminal tracking can't stall.
+
+### Changed
+
+- README gains a concise "At a glance" feature list for the plugin listing.
+
 ## [1.0.0] - 2026-08-15
 
 Initial marketplace release.

--- a/Model.js
+++ b/Model.js
@@ -133,8 +133,11 @@ function totalFor(days, key) {
 }
 
 function prevKey(key) {
+  if (!key) return ""
   var parts = String(key).split("-")
+  if (parts.length !== 3) return ""
   var d = new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]))
+  if (isNaN(d.getTime())) return ""
   d.setDate(d.getDate() - 1)
   return dayKey(d)
 }
@@ -144,15 +147,19 @@ function prevKey(key) {
 var WEEKDAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 
 function relativeDayLabel(key, todayKey) {
+  if (!key) return ""
   if (key === todayKey) return "Today"
   if (key === prevKey(todayKey)) return "Yesterday"
   var parts = String(key).split("-")
+  if (parts.length !== 3) return ""
   var d = new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]))
+  if (isNaN(d.getTime())) return ""
   return WEEKDAY_NAMES[d.getDay()]
 }
 
 // Last 7 day keys ending at todayKey, oldest first.
 function weekKeys(todayKey) {
+  if (!todayKey) return []
   var keys = []
   var key = todayKey
   for (var i = 0; i < 7; i++) {
@@ -177,6 +184,7 @@ function busiestWeekDay(days, todayKey) {
 // { key, ms, label, isToday } where label is the consistent 3-letter
 // weekday; today is told apart by its full-accent bar instead.
 function weekTrend(days, todayKey) {
+  if (!todayKey) return []
   var keys = weekKeys(todayKey)
   var out = []
   for (var i = 0; i < keys.length; i++) {

--- a/Panel.qml
+++ b/Panel.qml
@@ -18,20 +18,24 @@ Panel {
   // The bar tracks the widget mounted in its slot — BarWidget.qml — so the
   // popout coordinator and panel switching must identify us by that widget.
   readonly property var service: bar && bar.shell ? bar.shell.serviceFor("agx.screen-time") : null
+  readonly property bool serviceReady: service && service.ready === true
   readonly property var today: service ? service.today : null
   readonly property var days: service ? service.days : {}
-  readonly property string todayKey: service ? service.todayKey : ""
+  readonly property string todayKey: serviceReady ? service.todayKey : ""
 
-  readonly property var apps: Model.groupedApps(Model.appList(root.today), Model.DONUT_MAX_SLICES)
-  readonly property var insightRows: Model.insights(root.today, root.days, root.todayKey)
-  readonly property var weekTrend: Model.weekTrend(root.days, root.todayKey)
+  // All derived data is gated on service.ready: before the service has
+  // loaded its history, todayKey is "" and the Model helpers would produce
+  // garbage labels ("NaN-NaN-NaN") instead of an empty chart.
+  readonly property var apps: serviceReady ? Model.groupedApps(Model.appList(root.today), Model.DONUT_MAX_SLICES) : []
+  readonly property var insightRows: serviceReady ? Model.insights(root.today, root.days, root.todayKey) : []
+  readonly property var weekTrend: serviceReady ? Model.weekTrend(root.days, root.todayKey) : []
   readonly property double weekMax: {
     var max = 0
     var list = root.weekTrend
     for (var i = 0; i < list.length; i++) max = Math.max(max, Number(list[i].ms) || 0)
     return max
   }
-  readonly property double todayTotal: root.today ? (root.today.total || 0) : 0
+  readonly property double todayTotal: serviceReady ? (root.today.total || 0) : 0
   property bool patternsExpanded: false
 
   // ---- Donut chart state ------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ down into a donut chart with a 7-day usage trend.
   <img src="assets/patterns.png" width="47%" alt="Panel with the usage-patterns section expanded"/>
 </p>
 
+## At a glance
+
+- **Time in the bar** — today's total, live, right next to your tray.
+- **Icon-only mode** — right-click to collapse the widget to a single glyph; remembered.
+- **Per-app tracking** — focus time per app; idle, locked and desktop time never counted.
+- **Terminal-aware** — a focused terminal reports what's really running inside (opencode, not foot).
+- **Donut breakdown** — today's apps in a ring with a legend; six biggest + "Other".
+- **Usage patterns** — press `p` for a 7-day trend, top app, vs. yesterday, and your busiest day.
+- **Private by design** — local append-only JSON, pruned after 31 days; colours follow your theme.
+
 ## Features
 
 - **Per-app tracking** — focus time is accrued per app; idle, locked and

--- a/Service.qml
+++ b/Service.qml
@@ -37,11 +37,18 @@ Item {
   // When the active toplevel is one of these, Service resolves the pty's
   // foreground process group via resolve_app.py.
   readonly property var terminalAppIds: ["foot", "alacritty", "kitty", "ghostty",
-    "wezterm", "konsole", "gnome-terminal", "tilix", "xfce4-terminal", "termite", "st"]
+    "wezterm", "konsole", "gnome-terminal", "tilix", "xfce4-terminal", "termite", "st",
+    "org.omarchy.terminal"]
 
   // Retention window in days. History older than this is pruned on load and
   // before every write, so the append-only JSON can't grow without bound.
   readonly property int keepDays: 31
+
+  // A timer tick arriving far later than its cadence means the machine was
+  // suspended (or the clock jumped); wall-clock deltas across that gap are
+  // not screen time. Mirrors the lock service's suspend-gap heuristic.
+  readonly property int suspendGapMs: 5 * 60 * 1000
+  property double lastTick: 0
 
   // ---- Live state, exposed to the bar widget and panel. These are always
   //      REPLACED with fresh objects, never mutated in place, so QML
@@ -76,6 +83,21 @@ Item {
     return appId && root.terminalAppIds.indexOf(appId.toLowerCase()) !== -1
   }
 
+  // Windows that are never user-facing screen time — the idle screensaver,
+  // xdg desktop portal windows that steal focus. These open no bucket, so
+  // they count neither as an app nor into today's total.
+  function shouldTrack(appId) {
+    if (!appId) return false
+    var id = String(appId).toLowerCase()
+    if (id === "org.omarchy.screensaver") return false
+    if (id.indexOf("xdg-desktop-portal") === 0) return false
+    return true
+  }
+
+  function isSuspendGap(now) {
+    return root.lastTick > 0 && (now - root.lastTick) > root.suspendGapMs
+  }
+
   function switchActive() {
     var now = Date.now()
     root.closeActiveBucket(now)
@@ -83,13 +105,18 @@ Item {
     var app = tl && tl.appId ? tl.appId : ""
     root.rawApp = app
     root.resolveInFlight = false
+    if (app && !root.shouldTrack(app)) {
+      root.activeApp = ""
+      root.activeStart = 0
+      return
+    }
     if (app && root.isTerminal(app)) {
       // Open the bucket once the pty's foreground app is known.
       root.activeApp = ""
       root.activeStart = 0
       root.resolveForApp = app
       root.resolveInFlight = true
-      resolverProc.running = true
+      if (!resolverProc.running) resolverProc.running = true
     } else {
       root.activeApp = Model.canonicalApp(app)
       root.activeStart = app ? now : 0
@@ -118,6 +145,13 @@ Item {
     if (!root.ready) return
     var app = root.activeApp
     if (!app || !root.activeStart) return
+    if (root.isSuspendGap(now)) {
+      // The machine was asleep; don't credit the wall-clock gap as screen
+      // time. Drop the stale bucket and let tracking restart fresh.
+      root.activeApp = ""
+      root.activeStart = 0
+      return
+    }
     var dur = Math.max(0, now - root.activeStart)
     var startMs = root.activeStart
     root.activeApp = ""
@@ -145,6 +179,10 @@ Item {
   // the timer so a crash loses at most the current interval.
   function commitElapsed(now) {
     if (!root.ready || !root.activeApp || !root.activeStart) return
+    if (root.isSuspendGap(now)) {
+      root.activeStart = now
+      return
+    }
     var dur = Math.max(0, now - root.activeStart)
     if (dur <= 0) return
     var apps = Object.assign({}, root.today.apps)
@@ -206,6 +244,7 @@ Item {
         : Model.newDay()
       root.ready = true
       root.startupPhase = false
+      root.lastTick = Date.now()
       root.switchActive()
     } else {
       // Retry after a seed: keep the live bucket, just refresh the mirror.
@@ -217,12 +256,18 @@ Item {
 
   function onHistoryLoadFailed() {
     // Expected on the very first run (file seeded by ensureDirProc) and on
-    // a malformed file. Start empty rather than refusing to track.
+    // a malformed file. Preserve a corrupt file before the next persist
+    // overwrites it, then start empty rather than refusing to track.
     console.warn("agx.screen-time: history load failed, starting empty")
+    if (!root.backupAttempted) {
+      root.backupAttempted = true
+      backupProc.running = true
+    }
     if (!root.ready) {
       root.days = {}
       root.ready = true
       root.startupPhase = false
+      root.lastTick = Date.now()
       root.switchActive()
     }
   }
@@ -263,6 +308,16 @@ Item {
     }
   }
 
+  // Preserve a corrupt history file before the next persist overwrites it.
+  // Only a non-empty file that fails to parse is moved aside, so transient
+  // load errors never destroy a valid history.
+  property bool backupAttempted: false
+  Process {
+    id: backupProc
+    command: ["bash", "-c",
+      "f=\"$HOME/.config/omarchy/screen-time/history.json\"; if [[ -s \"$f\" ]] && ! python3 -c 'import json,sys; json.load(open(sys.argv[1]))' \"$f\" 2>/dev/null; then mv -f \"$f\" \"$f.corrupt-$(date +%s)\"; fi"]
+  }
+
   // A terminal's foreground process changes without the compositor noticing
   // (opencode exits, leaving bash). Re-resolve while a terminal is focused.
   Timer {
@@ -273,8 +328,19 @@ Item {
     onTriggered: {
       root.resolveForApp = root.rawApp
       root.resolveInFlight = true
-      resolverProc.running = true
+      if (!resolverProc.running) resolverProc.running = true
     }
+  }
+
+  // If a resolver run never exits (hung hyprctl, wedged /proc read), clear
+  // the in-flight flag so the refresh timer can re-arm instead of stalling
+  // terminal tracking until the next focus change.
+  Timer {
+    id: resolveWatchdog
+    interval: 10000
+    repeat: false
+    running: root.resolveInFlight
+    onTriggered: root.resolveInFlight = false
   }
 
   // Resolves the app running in the focused terminal (see resolve_app.py).
@@ -296,8 +362,10 @@ Item {
     repeat: true
     running: root.ready
     onTriggered: {
+      var now = Date.now()
       root.rolloverIfNeeded()
-      root.commitElapsed(Date.now())
+      root.commitElapsed(now)
+      root.lastTick = now
     }
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "Screen Time",
   "version": "1.0.0",
   "author": "agx",
-  "description": "Tracks daily screen time per app, shows today's total in the bar, and summarizes usage patterns",
+  "description": "Per-app screen time in your bar: live today's total, donut breakdown and 7-day patterns. Icon-only mode, terminal-aware, fully local.",
   "kinds": [
     "service",
     "bar-widget"

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -88,6 +88,15 @@ test("prevKey handles month and year boundaries", () => {
   assert.equal(Model.prevKey("2026-01-01"), "2025-12-31")
 })
 
+test("empty or malformed keys never produce garbage day keys", () => {
+  assert.equal(Model.prevKey(""), "")
+  assert.equal(Model.prevKey("not-a-date"), "")
+  assert.deepEqual(Model.weekKeys(""), [])
+  assert.deepEqual(Model.weekTrend({}, ""), [])
+  assert.equal(Model.relativeDayLabel("", "2026-08-15"), "")
+  assert.equal(Model.relativeDayLabel("2026-08-15", ""), "Sat")
+})
+
 test("weekKeys returns 7 keys ending today", () => {
   const keys = Model.weekKeys("2026-08-15")
   assert.equal(keys.length, 7)


### PR DESCRIPTION
## Summary

Six long-term-robustness fixes for the screen-time plugin, plus a listing polish. All were verified on the live session before this PR.

## Changes

**Service.qml**
- **Suspend / clock jumps** — a timer tick arriving >5 min late (suspend or clock jump) no longer accrues wall-clock time as screen time. `closeActiveBucket`/`commitElapsed` drop or re-anchor the stale bucket; `lastTick` starts at `0` until the service is ready so the very first tick after boot is never treated as a gap.
- **Ignore-list** — `org.omarchy.screensaver` and `xdg-desktop-portal*` windows open no bucket, matching the documented "idle and locked time never counted" claim.
- **Corrupt history** — a non-empty `history.json` that fails to parse is moved aside to `history.json.corrupt-<ts>` (once, via `backupProc`) before tracking resumes; empty-file/first-run and transient errors never touch valid history.
- **`org.omarchy.terminal`** added to `terminalAppIds` so Omarchy's own terminal resolves to its foreground app.
- **Resolver guards** — `if (!resolverProc.running)` in both start sites plus a 10 s `resolveWatchdog` clears a stuck in-flight resolution so terminal tracking can't stall.

**Model.js** — `prevKey`/`relativeDayLabel`/`weekKeys`/`weekTrend` return `""`/`[]` for empty or malformed keys instead of `NaN-NaN-NaN` labels.

**Panel.qml** — chart data (`apps`/`insightRows`/`weekTrend`/`todayKey`/`todayTotal`) gated on `serviceReady`, eliminating 7× `Unable to assign [undefined] to QString` warnings per startup.

**Tests** — new empty-key guard cases (24 JS + 7 Python, all pass).

**Listing** — manifest description and a README "At a glance" feature list for the plugin page.

## Verification

- `node --test tests/model.test.js` — 24 pass
- `python3 -m unittest discover -s tests` — 7 pass
- `manifest.json` parses; backup command verified no-op on valid file
- `qmllint` — only pre-existing Quickshell dynamic-property noise
- Live shell reload: 0 startup warnings (was 7×), history loads and persists under the new code